### PR TITLE
Add Mod integration config and update forge's maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url = 'https://files.minecraftforge.net/maven' }
+        maven { url = 'https://maven.minecraftforge.net/' }
 		maven { url "https://repo.spongepowered.org/repository/maven-public/" }
         jcenter()
         mavenCentral()

--- a/src/main/java/net/smileycorp/raids/common/CommonProxy.java
+++ b/src/main/java/net/smileycorp/raids/common/CommonProxy.java
@@ -56,6 +56,7 @@ public class CommonProxy {
 		RaidConfig.syncConfig(event);
 		RaidTableLoader.init(event);
 		VillagerGiftsConfig.init(event);
+		IntegrationConfig.syncConfig(event);
 		PacketHandler.initPackets();
 		MinecraftForge.EVENT_BUS.register(new RaidsEventHandler());
 		MinecraftForge.EVENT_BUS.register(new RaidsWorldGenerator());

--- a/src/main/java/net/smileycorp/raids/config/IntegrationConfig.java
+++ b/src/main/java/net/smileycorp/raids/config/IntegrationConfig.java
@@ -1,0 +1,33 @@
+package net.smileycorp.raids.config;
+
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+
+import java.io.File;
+
+public class IntegrationConfig {
+    private static Configuration config;
+
+    public static boolean crossbows = true;
+    public static boolean crossbow = true;
+    public static boolean spartanweaponry = true;
+    public static boolean tconstruct = true;
+    public static boolean futuremc = true;
+    public static boolean tektopia = true;
+
+    public static void syncConfig(FMLPreInitializationEvent event) {
+        config = new Configuration(new File(event.getModConfigurationDirectory().getPath() + "/raids/integration.cfg"));
+        try {
+            config.load();
+            crossbows = config.get("general", "crossbows", true, "Only works if crossbows mod is installed").getBoolean();
+            crossbow = config.get("general", "crossbow", true, "Only works if crossbow mod is installed").getBoolean();
+            spartanweaponry = config.get("general", "spartanweaponry", true, "Only works if spartanweaponry mod is installed").getBoolean();
+            tconstruct = config.get("general", "tconstruct", true, "Only works if tconstruct mod is installed").getBoolean();
+            futuremc = config.get("general", "futuremc", true, "Only works if futuremc mod is installed").getBoolean();
+            tektopia = config.get("general", "tektopia", true, "Only works if tektopia mod is installed").getBoolean();
+        } catch (Exception e) {
+        } finally {
+            if (config.hasChanged()) config.save();
+        }
+    }
+}

--- a/src/main/java/net/smileycorp/raids/integration/ModIntegration.java
+++ b/src/main/java/net/smileycorp/raids/integration/ModIntegration.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.Loader;
 import net.smileycorp.raids.common.entities.EntityPillager;
 import net.smileycorp.raids.config.EntityConfig;
+import net.smileycorp.raids.config.IntegrationConfig;
 import net.smileycorp.raids.integration.crossbow.CrossbowIntegration;
 import net.smileycorp.raids.integration.crossbows.CrossbowsBackportIntegration;
 import net.smileycorp.raids.integration.futuremc.FutureMCIntegration;
@@ -18,12 +19,12 @@ import java.util.Random;
 import java.util.function.Function;
 
 public class ModIntegration {
-    public static boolean CROSSBOWS_BACKPORT_LOADED = Loader.isModLoaded("crossbows");
-    public static boolean CROSSBOW_LOADED = Loader.isModLoaded("crossbow");
-    public static boolean SPARTAN_LOADED = Loader.isModLoaded("spartanweaponry");
-    public static boolean TINKERS_LOADED = Loader.isModLoaded("tconstruct");
-    public static boolean FUTUREMC_LOADED = Loader.isModLoaded("futuremc");
-    public static boolean TEKTOPIA_LOADED = Loader.isModLoaded("tektopia");
+    public static boolean CROSSBOWS_BACKPORT_LOADED = Loader.isModLoaded("crossbows") && IntegrationConfig.crossbows;
+    public static boolean CROSSBOW_LOADED = Loader.isModLoaded("crossbow") && IntegrationConfig.crossbow;
+    public static boolean SPARTAN_LOADED = Loader.isModLoaded("spartanweaponry") && IntegrationConfig.spartanweaponry;
+    public static boolean TINKERS_LOADED = Loader.isModLoaded("tconstruct") && IntegrationConfig.tconstruct;
+    public static boolean FUTUREMC_LOADED = Loader.isModLoaded("futuremc") && IntegrationConfig.futuremc;
+    public static boolean TEKTOPIA_LOADED = Loader.isModLoaded("tektopia") && IntegrationConfig.tektopia;
     
     public static boolean HAS_CROSSBOW_MOD = CROSSBOWS_BACKPORT_LOADED || CROSSBOW_LOADED || SPARTAN_LOADED || TINKERS_LOADED;
     


### PR DESCRIPTION
Because of I'm using old version of futuremc, it doesn't have thedarkcolour/futuremc/client/gui/GuiVillager class, so I decided to add a configuration to decide whether to enable Mod integration. And the forge maven is old that I replaced it with the new.