### PR TITLE
more customized options to modify the raids

### DIFF
--- a/src/main/java/net/smileycorp/raids/common/event/CustomRaidEndEvent.java
+++ b/src/main/java/net/smileycorp/raids/common/event/CustomRaidEndEvent.java
@@ -1,0 +1,18 @@
+package net.smileycorp.raids.common.event;
+
+import net.smileycorp.raids.common.raid.Raid;
+
+public class CustomRaidEndEvent extends CustomRaidEvent {
+    
+    private final boolean win;
+    
+    public CustomRaidEndEvent(Raid raid, boolean win) {
+        super(raid);
+        this.win = win;
+    }
+    
+    public boolean isWin() {
+        return win;
+    }
+    
+}

--- a/src/main/java/net/smileycorp/raids/common/event/CustomRaidEvent.java
+++ b/src/main/java/net/smileycorp/raids/common/event/CustomRaidEvent.java
@@ -1,0 +1,57 @@
+package net.smileycorp.raids.common.event;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.smileycorp.raids.common.raid.Raid;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public abstract class CustomRaidEvent extends Event {
+    
+    private final Raid raid;
+    
+    protected CustomRaidEvent(Raid raid) {
+        this.raid = raid;
+    }
+    
+    public Raid getRaid() {
+        return raid;
+    }
+    
+    public World getWorld() {
+        return raid.getWorld();
+    }
+    
+    @Nullable
+    public EntityPlayer getPlayer() {
+        return raid.getCreator();
+    }
+    
+    public String getName() {
+        return raid.getRaidDisplayName();
+    }
+    
+    public int getWaves() {
+        return raid.getNumGroups();
+    }
+    
+    public BlockPos getPos() {
+        return raid.getCenter();
+    }
+    
+    public boolean requireVillage() {
+        return raid.requiresVillageCheck();
+    }
+    
+    public List<Class<? extends EntityLiving>> getDetectionWhiteList() {
+        return raid.getDetectionWhitelist();
+    }
+    
+    public String getBossBar() {
+        return raid.getBossbarTitle();
+    }
+}

--- a/src/main/java/net/smileycorp/raids/common/event/CustomRaidStartEvent.java
+++ b/src/main/java/net/smileycorp/raids/common/event/CustomRaidStartEvent.java
@@ -1,0 +1,13 @@
+package net.smileycorp.raids.common.event;
+
+import net.smileycorp.raids.common.raid.Raid;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+@Cancelable
+public class CustomRaidStartEvent extends CustomRaidEvent {
+    
+    public CustomRaidStartEvent(Raid raid) {
+        super(raid);
+    }
+    
+}

--- a/src/main/java/net/smileycorp/raids/common/event/CustomRaidTickEvent.java
+++ b/src/main/java/net/smileycorp/raids/common/event/CustomRaidTickEvent.java
@@ -1,0 +1,31 @@
+package net.smileycorp.raids.common.event;
+
+import net.smileycorp.raids.common.raid.Raid;
+
+public class CustomRaidTickEvent extends CustomRaidEvent {
+    
+    private final int wave;
+    private Boolean endState;
+    
+    public CustomRaidTickEvent(Raid raid, int wave) {
+        super(raid);
+        this.wave = Math.max(1, wave);
+    }
+    
+    public int getWave() {
+        return wave;
+    }
+    
+    public void setEnd(boolean win) {
+        endState = win;
+    }
+    
+    public boolean shouldEndRaid() {
+        return endState != null;
+    }
+    
+    public boolean endAsWin() {
+        return Boolean.TRUE.equals(endState);
+    }
+    
+}

--- a/src/main/java/net/smileycorp/raids/common/event/CustomRaidWaveEndEvent.java
+++ b/src/main/java/net/smileycorp/raids/common/event/CustomRaidWaveEndEvent.java
@@ -1,0 +1,18 @@
+package net.smileycorp.raids.common.event;
+
+import net.smileycorp.raids.common.raid.Raid;
+
+public class CustomRaidWaveEndEvent extends CustomRaidEvent {
+    
+    private final int wave;
+    
+    public CustomRaidWaveEndEvent(Raid raid, int wave) {
+        super(raid);
+        this.wave = wave;
+    }
+    
+    public int getWave() {
+        return wave;
+    }
+    
+}

--- a/src/main/java/net/smileycorp/raids/common/event/CustomRaidWaveStartEvent.java
+++ b/src/main/java/net/smileycorp/raids/common/event/CustomRaidWaveStartEvent.java
@@ -1,0 +1,24 @@
+package net.smileycorp.raids.common.event;
+
+import net.smileycorp.raids.common.raid.Raid;
+
+public class CustomRaidWaveStartEvent extends CustomRaidEvent {
+    
+    private int wave;
+    
+    public CustomRaidWaveStartEvent(Raid raid, int wave) {
+        super(raid);
+        this.wave = Math.max(1, wave);
+    }
+    
+    public int getWave() {
+        return wave;
+    }
+    
+    public boolean setWave(int wave) {
+        if (wave <= 0) return false;
+        this.wave = wave;
+        return true;
+    }
+    
+}

--- a/src/main/java/net/smileycorp/raids/common/raid/RaidHelper.java
+++ b/src/main/java/net/smileycorp/raids/common/raid/RaidHelper.java
@@ -1,0 +1,102 @@
+package net.smileycorp.raids.common.raid;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldServer;
+import net.smileycorp.raids.config.RaidConfig;
+import net.smileycorp.raids.config.raidevent.RaidSpawnTable;
+import net.smileycorp.raids.common.util.RaidsLogger;
+import net.smileycorp.raids.common.event.CustomRaidStartEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import net.minecraftforge.registries.GameData;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public final class RaidHelper {
+    
+    private static final double DEFAULT_DETECTION_RADIUS = 48.0D;
+    
+    private RaidHelper() {
+    }
+    
+    public static Optional<Raid> triggerRaid(WorldServer world, BlockPos pos, @Nullable EntityPlayerMP player,
+            String tableName, boolean requireVillageCheck, @Nullable List<String> detectionWhitelist,
+            @Nullable String bossbarName, @Nullable Integer waveOverride) {
+        if (world == null || pos == null || tableName == null) return Optional.empty();
+        RaidSpawnTable table = RaidHandler.getSpawnTable(tableName);
+        if (table == null) {
+            RaidsLogger.logError("Unable to locate raid table " + tableName, new IllegalArgumentException(tableName));
+            return Optional.empty();
+        }
+        if (requireVillageCheck && !Raid.isVillage(world, pos)) return Optional.empty();
+        List<Class<? extends EntityLiving>> whitelist = resolveWhitelist(detectionWhitelist);
+        if (!hasEligibleTargets(world, pos, whitelist)) return Optional.empty();
+        Integer normalizedWaves = waveOverride != null ? Math.max(1, waveOverride) : null;
+        WorldDataRaids data = WorldDataRaids.getData(world);
+        if (data.getRaidAt(pos) != null) {
+            RaidsLogger.logError("Raid already active at " + pos, new IllegalStateException());
+            return Optional.empty();
+        }
+        Raid raid = data.forceStartRaid(pos, table, !requireVillageCheck, normalizedWaves);
+        if (raid == null) return Optional.empty();
+        String raidName = stripExtension(table.getName());
+        raid.configureCustomRaid(player, requireVillageCheck, whitelist, bossbarName, raidName);
+        CustomRaidStartEvent event = new CustomRaidStartEvent(raid);
+        if (MinecraftForge.EVENT_BUS.post(event)) {
+            data.removeRaid(raid);
+            return Optional.empty();
+        }
+        if (player != null) RaidOmenTracker.setRaidStart(player);
+        return Optional.of(raid);
+    }
+    
+    private static boolean hasEligibleTargets(WorldServer world, BlockPos pos, Collection<Class<? extends EntityLiving>> detectionWhitelist) {
+        AxisAlignedBB area = new AxisAlignedBB(pos).grow(DEFAULT_DETECTION_RADIUS);
+        return !world.getEntitiesWithinAABB(EntityLiving.class, area, entity -> matchesDetection(entity, detectionWhitelist)).isEmpty();
+    }
+    
+    private static boolean matchesDetection(EntityLiving entity, Collection<Class<? extends EntityLiving>> detectionWhitelist) {
+        if (detectionWhitelist == null || detectionWhitelist.isEmpty()) {
+            return entity instanceof EntityVillager || RaidConfig.isTickableVillager(entity);
+        }
+        for (Class<? extends EntityLiving> clazz : detectionWhitelist) {
+            if (clazz != null && clazz.isAssignableFrom(entity.getClass())) return true;
+        }
+        return false;
+    }
+
+    private static List<Class<? extends EntityLiving>> resolveWhitelist(@Nullable List<String> ids) {
+        if (ids == null || ids.isEmpty()) return Collections.emptyList();
+        List<Class<? extends EntityLiving>> result = new ArrayList<>();
+        for (String id : ids) {
+            if (id == null || id.trim().isEmpty()) continue;
+            try {
+                ResourceLocation loc = new ResourceLocation(id);
+                EntityEntry entry = GameData.getEntityRegistry().getValue(loc);
+                if (entry != null && EntityLiving.class.isAssignableFrom(entry.getEntityClass())) {
+                    result.add((Class<? extends EntityLiving>) entry.getEntityClass());
+                } else RaidsLogger.logError("Invalid detection whitelist entity " + id, new IllegalArgumentException("Entity not found or not living"));
+            } catch (Exception e) {
+                RaidsLogger.logError("Failed resolving detection whitelist entity " + id, e);
+            }
+        }
+        return result;
+    }
+
+    private static String stripExtension(String name) {
+        if (name == null) return "";
+        int index = name.lastIndexOf('.');
+        return index == -1 ? name : name.substring(0, index);
+    }
+    
+}


### PR DESCRIPTION
Added a RaidHelper API layer so scripts and other mods can trigger fully customized raids without rewriting the internals.

Enhanced custom raids with configurable metadata, bossbar text, detection whitelist, optional village requirements, hero-of-the-village suppression, and per-dimension storage with correct cross-dimension spawning.

Implemented wave-count overrides plus start/wave-start/wave-end/tick events, so listeners can adjust waves or end raids programmatically.

Modpack authors can now use CraftTweaker (ZenUtils native) or KubeJS to call the helper and event listeners, making it easy to script brand-new, highly customized raids.